### PR TITLE
Changes the Google API deps to google.golang.org

### DIFF
--- a/gitkit/api.go
+++ b/gitkit/api.go
@@ -26,7 +26,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/google-api-go-client/googleapi"
+	"google.golang.org/api/googleapi"
 )
 
 // Bytes is a slice of bytes.


### PR DESCRIPTION
I found out that the source cannot be compiled with googleapi dependency from github. So I changed it to google.golang.org and it works and tests are passed.