### PR TITLE
Get browser API key and client ID via Gitkit getProjectConfig API

### DIFF
--- a/gitkit/config.go
+++ b/gitkit/config.go
@@ -22,6 +22,8 @@ import (
 
 // Config contains the configurations for creating a Client.
 type Config struct {
+	// BrowserAPIKey is the API key used to call Google API in web browser.
+	BrowserAPIKey string `json:"browserApiKey,omitempty"`
 	// ClientID is the Google OAuth2 client ID for the server.
 	ClientID string `json:"clientId,omitempty"`
 	// WidgetURL is the identitytoolkit javascript widget URL.
@@ -35,6 +37,8 @@ type Config struct {
 	WidgetModeParamName string `json:"widgetModeParamName,omitempty"`
 	// CookieName is the name of the cookie that stores the ID token.
 	CookieName string `json:"cookieName,omitempty"`
+	// SignInOptions are the sign in methods provided to users for sign in.
+	SignInOptions []string `json:"signInOptions,omitempty"`
 	// GoogleAppCredentialsPath is the path of the service account JSON key file
 	// downloaded from Google cloud console.
 	// Only specify it if you cannot use Google Application Default Credentials.


### PR DESCRIPTION
Get browser API key and client ID via Gitkit getProjectConfig API when running in App Engine, so that developers don't need to hardcode it in the code.